### PR TITLE
change URL for server.R on run_app.R

### DIFF
--- a/run_app.R
+++ b/run_app.R
@@ -40,7 +40,7 @@
                 destfile = "ui.R")
   
   ## Download most recent server.R file and save in node repo
-  download.file(url = "https://github.com/j-hagedorn/exploreSIS/blob/master/server.R", 
+    download.file(url = "https://raw.githubusercontent.com/j-hagedorn/exploreSIS/master/server.R", 
                 destfile = "server.R")
 
 #####################################################################


### PR DESCRIPTION
The URL was pointing to the entire html page instead of just the R code, throwing errors.  URL points to just the R code now.
